### PR TITLE
Selected song after removing an album from the playlist

### DIFF
--- a/public/js/Tunes.js
+++ b/public/js/Tunes.js
@@ -72,6 +72,7 @@
 
       reset: function() {
         player.pause();
+        paused = false;
         current.album = 0;
         current.track = 0;
       },

--- a/test-js/spec/TunesSpec.js
+++ b/test-js/spec/TunesSpec.js
@@ -278,6 +278,21 @@ describe('player service', function() {
         player.playlist.remove(albumData[0]); // nothing happend, not in the playlist
         expect(player.playlist.length).toBe(0);
       });
+      
+      it('should not continue playing a removed song after removing an album from the playlist', function() {
+        player.playlist.add(albumData[0]);
+        player.playlist.add(albumData[1]);
+        player.play();
+        expect(player.playing).toBe(true);
+        expect(audioMock.src).toBe("/music/Album A Track A.mp3");
+        
+        player.playlist.remove(albumData[0]);
+        expect(player.playing).toBe(false);
+        
+        player.play();
+        expect(player.playing).toBe(true);
+        expect(audioMock.src).toBe("/music/Album B Track A.mp3");
+      });
     });
   });
 });


### PR DESCRIPTION
Hi there,

I found a small problem in your otherwise very nice application.

**Steps to replicate:**
1. Open application.
2. Add both albums to the playlist.
3. Start playing.
4. Remove the played album from the playlist.
5. Start playing again.

What is played now is still the song that has been playing when the album was removed from the playlist instead of the currently selected song.

I added the tiny fix needed to make this working and the corresponding test case. It might be even more concise to have a `player.stopped` variable to handle this, but I think this is sufficient for now.

With kind regards,
Marc

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/peepcode-tunes/2)

<!-- Reviewable:end -->
